### PR TITLE
Secuirty/sql injection vector

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -16,7 +16,7 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
       <INDEXES>
-        <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
+        <INDEX NAME="courseid" UNIQUE="true" FIELDS="courseid"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/lib.php
+++ b/lib.php
@@ -72,7 +72,6 @@ function block_acclaim_get_block_course($course_id)
 function block_acclaim_write_badge_to_issue($fromform)
 {
     global $DB;
-    $table = 'block_acclaim';
 
     $fromform = block_acclaim_update_form_with_badge_name($fromform);
     $DB->delete_records('block_acclaim',  array('courseid' => $fromform->courseid));

--- a/lib.php
+++ b/lib.php
@@ -75,11 +75,7 @@ function block_acclaim_write_badge_to_issue($fromform)
     $table = 'block_acclaim';
 
     $fromform = block_acclaim_update_form_with_badge_name($fromform);
-
-    $exists = $DB->record_exists_select($table, "courseid = '{$fromform->courseid}'");
-        if($exists){
-        $DB->delete_records_select($table, "courseid = '{$fromform->courseid}'");
-    }
+    $DB->delete_records('block_acclaim',  array('courseid' => $fromform->courseid));
 
     return $DB->insert_record('block_acclaim', $fromform);
 }

--- a/tests/acclaim_test.php
+++ b/tests/acclaim_test.php
@@ -134,7 +134,7 @@ class acclaim_lib_test extends advanced_testcase{
        $result = block_acclaim_write_badge_to_issue($fromform);
        $count = $DB->count_records_select($table, "courseid = '38'");
 
-       $this->assertEquals($count,1);
+       $this->assertEquals(1,$count);
    }
 
    public function test_create_array()


### PR DESCRIPTION
This PR sanitizes the input to `delete_records` [here](https://github.com/YourAcclaim/block_acclaim/commit/7c8a11700717c992cd0a9ecd12175b0275173dc2).  This `delete_records` call is used such that if a `badge_template` was already selected, and next, a different badge_template is selected, the associated table will call `delete_records` on the previous and insert the most recent.  The superfluous code was removed which checked if it existed before deleting and instead simplified to just call `delete_records` as suggested in https://github.com/YourAcclaim/block_acclaim/issues/8 regardless of if a record already exists and the tablename is no longer stored in a variable [here](https://github.com/YourAcclaim/block_acclaim/commit/36be9a43efd16b905c6d75db139a613ae2e905a3).  Lastly, the ultimate goal is to not allow more than one `course_id` to exist currently, and so, a constraint was added [here](https://github.com/YourAcclaim/block_acclaim/commit/2f0e81c88ab4d65b408619da583dd1e7dbd7e8ac) to further enforce the expected behavior.