### PR TITLE
Add missing upgrade script to account for db changes in version 2019080211 [ADS-61]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Installation
 To install this block plugin:
 
 <ol>
-  <li>Clone this repository</li>
-  <li>Remove directory .git and .gitignore </li>
-  <li>Rename the top level directory from block_acclaim -> acclaim
-  <li>Zip the repository directory acclaim and name acclaim.zip</li>
+  <li>Navigate to the release tab and download the latest release zip. github.com/YourAcclaim/block_acclaim/releases</li>
+  <li>Unzip the zip file and rename the top level directory to acclaim
+  <li>Rezip the directory and name the zip file acclaim.zip</li>
   <li>Login to Moodle as Administrator</li>
   <li>Navigate to: Site Administration > Plugins > Install Plugins</li>
   <li>Under Plugin type, choose “Block”</li>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ To install this block plugin:
 <ol>
   <li>Clone this repository</li>
   <li>Remove directory .git and .gitignore </li>
-  <li>Zip the repository directory block_acclaim and name acclaim.zip</li>
+  <li>Rename the top level directory from block_acclaim -> acclaim
+  <li>Zip the repository directory acclaim and name acclaim.zip</li>
   <li>Login to Moodle as Administrator</li>
   <li>Navigate to: Site Administration > Plugins > Install Plugins</li>
   <li>Under Plugin type, choose “Block”</li>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,4 +1,4 @@
-
+<?php
 /**
  * Credly's Acclaim Moodle Block Plugin
  * Credly: http://youracclaim.com

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,3 +1,13 @@
+/**
+ * Credly's Acclaim Moodle Block Plugin
+ * Credly: http://youracclaim.com
+ * Moodle: http://moodle.org/
+ *
+ * @package    block_acclaim
+ * @copyright  2020 Credly, Inc. <http://youracclaim.com>
+ * @license    https://opensource.org/licenses/MIT
+ */
+
 function xmldb_qtype_myqtype_upgrade($oldversion) {
     global $DB;
     $dbman = $DB->get_manager();

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,3 +1,4 @@
+
 /**
  * Credly's Acclaim Moodle Block Plugin
  * Credly: http://youracclaim.com
@@ -8,7 +9,7 @@
  * @license    https://opensource.org/licenses/MIT
  */
 
-function xmldb_qtype_myqtype_upgrade($oldversion) {
+function xmldb_block_acclaim_upgrade($oldversion) {
     global $DB;
     $dbman = $DB->get_manager();
     /// Add a new column newcol to the mdl_myqtype_options

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,36 @@
+function xmldb_qtype_myqtype_upgrade($oldversion) {
+    global $DB;
+    $dbman = $DB->get_manager();
+    /// Add a new column newcol to the mdl_myqtype_options
+    if ($oldversion < 2020042200) {
+
+        // Define table block_acclaim_pending_badges to be created.
+        $table = new xmldb_table('block_acclaim_pending_badges');
+
+        // Adding fields to table block_acclaim_pending_badges.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('badgetemplateid', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('firstname', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('lastname', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('recipientemail', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('expiration', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table block_acclaim_pending_badges.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+
+        // Conditionally launch create table for block_acclaim_pending_badges.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table block_acclaim to be renamed to block_acclaim_courses.
+        $table = new xmldb_table('block_acclaim');
+
+        // Launch rename table for block_acclaim_courses.
+        $dbman->rename_table($table, 'block_acclaim_courses');
+
+        // Acclaim savepoint reached.
+        upgrade_block_savepoint(true, 2020042200, 'acclaim');
+    }
+    return true;
+}

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2019080211;  // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2020042200;  // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires  = 2014050800;        // Requires this Moodle version
 $plugin->component = 'block_acclaim'; // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION
https://acclaim.atlassian.net/projects/ADS/board?issue-key=ADS-61

This PR adds a missing file `upgrade.php` which the moodle api docs specify needs to be added to allow for moodle to upgrade an existing plug in database from one version to another. 

The code here looks a bit out of nowhere but all of it is pretty much auto generated by moodle's XMLEditorTool which you can access by launching a local moodle server and installing this plug in. 

This basically adds the missing db migrations that the previous version should have had and slaps on a new version so in order for the client who is experiencing this problem to fix they can just upgrade to a new version. 

I worried a while about the scenario where
A - This version
B - Previous version (problem version missing upgrade.php)
C - Previous previous version 

If a user happened to upgrade from C -> B -> A that it would duplicate the db changes but that actually is something we wouldnt have to worry about because in version B upgrade.php doesnt exist. 