### PR TITLE
Select badge UI not saving

### DIFF
--- a/block_acclaim.php
+++ b/block_acclaim.php
@@ -53,18 +53,19 @@ class block_acclaim extends block_base {
      * Display specialized text for the course block (the selected badge name).
      */
     public function specialization() {
-        if (isset($this->config)) {
-            global $COURSE;
-            $course_id = $COURSE->id;
-
-            $badge_name = $this->acclaim->get_course_info($course_id, 'badgename');
-
-            if ($badge_name == '') {
-                $badge_name = 'No Badge Selected';
-            }
-
-            $this->config->text = $badge_name;
+        if(!isset($this->config)){
+            $this->config = new stdClass();
         }
+        global $COURSE;
+        $course_id = $COURSE->id;
+
+        $badge_name = $this->acclaim->get_course_info($course_id, 'badgename');
+
+        if ($badge_name == '') {
+            $badge_name = 'No Badge Selected';
+        }
+
+        $this->config->text = $badge_name;
     }
 
     /**
@@ -114,16 +115,8 @@ class block_acclaim extends block_base {
         );
     
         $context = context_course::instance($COURSE->id);
-        $block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $COURSE->id));
         if (has_capability('block/acclaim:editbadge', $this->context)) {
-            if ($block_acclaim_course) {
-                $this->content->footer = html_writer::link($url, 'Change Badge');
-            } else {
-                $this->content->footer = html_writer::link($url, get_string('select_badge', 'block_acclaim'));
-            }
-        }
-        if ($block_acclaim_course){
-            $this->content->text .= $block_acclaim_course->badgename . ' (Currently Selected)';
+            $this->content->footer = html_writer::link($url, get_string('select_badge', 'block_acclaim'));
         }
         return $this->content;
     }

--- a/block_acclaim.php
+++ b/block_acclaim.php
@@ -61,7 +61,7 @@ class block_acclaim extends block_base {
 
         $badge_name = $this->acclaim->get_course_info($course_id, 'badgename');
 
-        if ($badge_name == '') {
+        if (!isset($badge_name) || $badge_name == '') {
             $badge_name = 'No Badge Selected';
         }
 

--- a/block_acclaim.php
+++ b/block_acclaim.php
@@ -114,8 +114,16 @@ class block_acclaim extends block_base {
         );
     
         $context = context_course::instance($COURSE->id);
+        $block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $COURSE->id));
         if (has_capability('block/acclaim:editbadge', $this->context)) {
-            $this->content->footer = html_writer::link($url, get_string('select_badge', 'block_acclaim'));
+            if ($block_acclaim_course) {
+                $this->content->footer = html_writer::link($url, 'Change Badge');
+            } else {
+                $this->content->footer = html_writer::link($url, get_string('select_badge', 'block_acclaim'));
+            }
+        }
+        if ($block_acclaim_course){
+            $this->content->text .= $block_acclaim_course->badgename . ' (Currently Selected)';
         }
         return $this->content;
     }

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020060300;  // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2020060500;  // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires  = 2014050800;        // Requires this Moodle version
 $plugin->component = 'block_acclaim'; // Full name of the plugin (used for diagnostics)

--- a/view.php
+++ b/view.php
@@ -52,6 +52,9 @@ $acclaim_form_data = new block_acclaim_form();
 
 $toform['blockid'] = $blockid;
 $toform['courseid'] = $courseid;
+if($block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $courseid))){
+    $toform['badgeid'] = $block_acclaim_course->badgeid;
+}
 
 $acclaim_form_data->set_data($toform);
 

--- a/view.php
+++ b/view.php
@@ -52,7 +52,8 @@ $acclaim_form_data = new block_acclaim_form();
 
 $toform['blockid'] = $blockid;
 $toform['courseid'] = $courseid;
-if($block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $courseid))){
+$block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $courseid))
+if ($block_acclaim_course) {
     $toform['badgeid'] = $block_acclaim_course->badgeid;
 }
 

--- a/view.php
+++ b/view.php
@@ -52,7 +52,7 @@ $acclaim_form_data = new block_acclaim_form();
 
 $toform['blockid'] = $blockid;
 $toform['courseid'] = $courseid;
-$block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $courseid))
+$block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $courseid));
 if ($block_acclaim_course) {
     $toform['badgeid'] = $block_acclaim_course->badgeid;
 }


### PR DESCRIPTION
https://acclaim.atlassian.net/browse/ADS-120

This PR addresses an issue where a client was not seeing the selected badge being updated on the block UI view. To be clear this badge **was being saved in the backend**, its just that the UI was not accurately reflecting this change. 

The problem was that the code that was handling updating the name [was not being executed since we have a check that the config is set which it is not initially](https://github.com/YourAcclaim/block_acclaim/pull/40/files#diff-a2965263496568647a9813131ce11259L56). 

The reason why it worked before (we used to not have a null check) is that PHP will implicitly create an object even from a null value if you write object operations
```
$this->config = NULL;
$this->config->text = "foo"; //this works
```

We fix this issue by[ initializing `$this->config` to an empty object](https://github.com/YourAcclaim/block_acclaim/pull/40/files#diff-a2965263496568647a9813131ce11259R57) if the config is not set initially so the rest of the code executes. 

The second fix was a bug that was present in the old version of the plugin in that when changing a badge for a course the form did populate the select form with the previously selected badge which contributed to the confusion of the client in them thinking the badge wasnt actually saving. 

The fix is to simply [populate the $toform variable](https://github.com/YourAcclaim/block_acclaim/pull/40/files#diff-bc8a20f246ad96d295d6336e0cc52d8dR56) which we use to [prepopulate the form with default selected values](https://github.com/YourAcclaim/block_acclaim/blob/bf7a43d5aa6604ccf235f2f900ea5d5a97adc6ce/view.php#L59)