### PR TITLE
Added expiration date field value in edit form state

### DIFF
--- a/view.php
+++ b/view.php
@@ -55,6 +55,7 @@ $toform['courseid'] = $courseid;
 $block_acclaim_course = $DB->get_record('block_acclaim_courses', array('courseid' => $courseid));
 if ($block_acclaim_course) {
     $toform['badgeid'] = $block_acclaim_course->badgeid;
+    $toform['expiration'] = $block_acclaim_course->expiration;
 }
 
 $acclaim_form_data->set_data($toform);


### PR DESCRIPTION
Hi,
If an existing block is being edited, it is not showing the value saved in db. This commit will resolve this issue.
To create the issue follow the below steps:
- Add a acclaim block to a course
- Add expiration date and save it
- Once saved, click on the block title again and you will see that the save date is not shown and the enabled checkbox is not ticked


Regards,

Sumaiya