### PR TITLE
Fixed Loop Issue By Adding JSON Decode

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -194,6 +194,7 @@ class block_acclaim_lib {
 
         $json = $this->query_api(null);
         $this->accumulate_badge_names($json, $badge_items, $badge_urls);
+        $json = json_decode($json, true);
 
         $next_page_url = '';
         if (isset($json['metadata'])) {
@@ -203,6 +204,7 @@ class block_acclaim_lib {
             while (!is_null($next_page_url)) {
                 $json = $this->query_api("$next_page_url&sort=name&filter=state::active");
                 $this->accumulate_badge_names($json, $badge_items, $badge_urls);
+                $json = json_decode($json, true);
 
                 if (isset($json['metadata'])) {
                     $metadata = $json['metadata'];


### PR DESCRIPTION
Added json decode to fix look up issue to go into pagination loop process as it wasn't seeing the next_page_url before after merging the older PR with my last update.  (lesson learned don't merge old prs from previous devs or thoroughly test if you)