### PR TITLE
bug: [CRED-3828] Moodle badgeurl upgrade error

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -11,7 +11,7 @@
         <FIELD NAME="badgeid" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Badge Template ID"/>
         <FIELD NAME="expiration" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Badge Expiration"/>
         <FIELD NAME="badgename" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Badge Name"/>
-        <FIELD NAME="badgeurl" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Badge URL"/>
+        <FIELD NAME="badgeurl" TYPE="char" LENGTH="1000" NOTNULL="true" DEFAULT="none-set" SEQUENCE="false" COMMENT="Badge URL"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -84,5 +84,15 @@ function xmldb_block_acclaim_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2024013100, 'acclaim');
     }
 
+    if ($oldversion < 2024040800) {
+        $table = new xmldb_table('block_acclaim_courses');
+        $field = new xmldb_field('badgeurl', XMLDB_TYPE_CHAR, '1000', null, XMLDB_NOTNULL, null, 'none-set', 'badgename');
+
+        $dbman->change_field_type($table, $field);
+
+        // Acclaim savepoint reached.
+        upgrade_block_savepoint(true, 2024040800, 'acclaim');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -60,9 +60,23 @@ function xmldb_block_acclaim_upgrade($oldversion) {
 
     if ($oldversion < 2024013100) {
         $table = new xmldb_table('block_acclaim_courses');
-        $field = new xmldb_field('badgeurl', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null, 'badgename');
+        $field = new xmldb_field('badgeurl', XMLDB_TYPE_CHAR, '1000', null, XMLDB_NOTNULL, null, 'none-set', 'badgename');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
+        }
+
+        $records = $DB->get_records(
+            'block_acclaim_courses',
+            ['badgeurl' => 'none-set'],
+            'id'
+        );
+
+        if ($records) {
+            $api = new block_acclaim_lib();
+            foreach ($records as $record) {
+                $record->badgeurl = $api->fetch_template_url($record->badgeid);
+                $DB->update_record('block_acclaim_courses', $record);
+            }
         }
 
         // Acclaim savepoint reached.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -57,5 +57,18 @@ function xmldb_block_acclaim_upgrade($oldversion) {
         // Acclaim savepoint reached.
         upgrade_block_savepoint(true, 2020042200, 'acclaim');
     }
+
+    if ($oldversion < 2024013100) {
+        $table = new xmldb_table('block_acclaim_courses');
+        $field = new xmldb_field('badgeurl', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null, 'badgename');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Acclaim savepoint reached.
+        // Beacon savepoint reached.
+        upgrade_block_savepoint(true, 2024013100, 'acclaim');
+    }
+
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -107,8 +107,6 @@ class block_acclaim_lib {
                 $url, $payload, array('CURLOPT_USERPWD' => block_acclaim_lib::$config->token . ':')
             );
 
-            print $curl->info['http_code'];
-
             if ($curl->info['http_code'] == 201) {
                 // The badge has been issued so we remove it from pending.
                 $DB->delete_records('block_acclaim_pending_badges',  array('id' => $badge->id));
@@ -286,7 +284,7 @@ class block_acclaim_lib {
      *   configured organization.
      * @return object - The JSON response.
      */
-    private function query_api($url) {
+    protected function query_api($url) {
         if (is_null($url)) {
             $config = self::$config;
             $url = "{$config->url}/organizations/{$config->org}/badge_templates?sort=name&filter=state::active";

--- a/lib.php
+++ b/lib.php
@@ -218,6 +218,30 @@ class block_acclaim_lib {
         return $badge_items;
     }
 
+    /**
+     * Send a request to Credly's Acclaim API to retrieve
+     * a single badge template URL
+     *
+     * @param string $id - ID of the template
+     * @return object - The JSON response.
+     */
+    public function fetch_template_url($id) {
+        if (is_null($url)) {
+            $config = self::$config;
+            $url = "{$config->url}/organizations/{$config->org}/badge_templates/{$id}";
+        }
+
+        $options = array('CURLOPT_USERPWD' => self::$config->token . ':');
+        $result = (new curl())->get($url, $params, $options);
+        $arr = json_decode($result, true);
+
+        if (!isset($arr['data'])) {
+            return 'unknown';
+        }
+
+        return $arr['data']['url'];
+    }
+
     ////////////////////
     // Private functions
     ////////////////////

--- a/settings.php
+++ b/settings.php
@@ -34,7 +34,7 @@ if ($ADMIN->fulltree) {
             'block_acclaim/url',
             get_string('setting_domain', 'block_acclaim'),
             null,
-            0,
+            array_keys($urls)[0],
             $urls
         )
     );

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023031500; // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2024013100; // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires  = 2014050800; // Requires this Moodle version
 $plugin->component = 'block_acclaim'; // Full name of the plugin (used for diagnostics)

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024013100; // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2024040800; // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires  = 2014050800; // Requires this Moodle version
 $plugin->component = 'block_acclaim'; // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION
- Incorporates changes from [this PR](https://github.com/YourAcclaim/block_acclaim/pull/5)
- Adds a migration path to populate the values and correct any discrepancies with the `badgeurl` column type
- Fixes failing test suite

Test suite output for this block:

![Screenshot 2024-04-08 at 9 43 47 AM](https://github.com/YourAcclaim/block_acclaim/assets/537469/09b46f38-4eb1-47e3-8499-dae2a97fe45d)

(we should get phpunit running in github actions so we can also automate compatibility checks with major moodle revisions)